### PR TITLE
ci: pin checkout SHA; always checkout z-shell/zd in reusable workflow

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -44,7 +44,9 @@ jobs:
       matrix:
         file: [annexes, ice, packages, plugins, snippets]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: z-shell/zd
 
       - name: Install zsh
         run: sudo apt-get update && sudo apt-get install -yq zsh


### PR DESCRIPTION
## Problem

When `test-native.yml` is called as a reusable workflow from another repo (e.g. `z-shell/zi`), `actions/checkout` without an explicit `repository:` checks out the **calling** repository, not `z-shell/zd`. This means the `tests/` directory (which lives in zd) is not present, and ZUnit fails with `Test file or directory not found`.

## Fix

- Pin `actions/checkout` to its v4 SHA
- Add `repository: z-shell/zd` so the test infrastructure is always available regardless of which repo calls this workflow

The zi repository is still cloned separately via the `Install zi` step using `zi_repo`/`zi_ref` inputs.