### PR TITLE
chore(zd): apply modelines and workflow conventions

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,5 +1,9 @@
 name: "ZUnit (Zsh matrix)"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   schedule:
     - cron: "0 3 * * 3"

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -1,5 +1,9 @@
 name: "ZUnit (native)"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/docker/utils.zsh
+++ b/docker/utils.zsh
@@ -1,4 +1,6 @@
 #!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
 
 # Functions to wrap container setup and initialization.
 


### PR DESCRIPTION
## Summary
- apply the standard Zsh modelines to Docker helper code
- add concurrency blocks to test workflows

## Validation
- `find docker tests -name '*.zsh' -print0 | xargs -0 -r -n1 zsh -n`
- workflow YAML parse audit
- `git diff --check origin/main...HEAD`