### PR TITLE
feat(ci): support immutable Zi refs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+paths:
+  .github/workflows/test-native.yml:
+    ignore:
+      # actionlint 1.7.12 predates this reusable-workflow context.
+      - 'property "workflow_sha" is not defined in object type'

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: z-shell/zd
+          ref: ${{ github.workflow_sha }}
 
       - name: Install zsh
         run: sudo apt-get update && sudo apt-get install -yq zsh

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -24,7 +24,7 @@ on:
         required: false
         default: ""
       zi_ref:
-        description: "Branch, tag, or SHA of zi to test."
+        description: "Branch, tag, or full commit SHA of zi to test."
         required: false
         default: "main"
   workflow_call:
@@ -35,7 +35,7 @@ on:
         required: false
         default: ""
       zi_ref:
-        description: "Branch, tag, or SHA of zi to test."
+        description: "Branch, tag, or full commit SHA of zi to test."
         type: string
         required: false
         default: "main"
@@ -48,7 +48,7 @@ jobs:
       matrix:
         file: [annexes, ice, packages, plugins, snippets]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: z-shell/zd
 
@@ -71,10 +71,21 @@ jobs:
           ZI_REF: ${{ inputs.zi_ref || 'main' }}
         run: |
           zi_home="${XDG_DATA_HOME:-${HOME}/.local/share}/zi"
-          git clone --depth 1 --branch "${ZI_REF}" \
-            "https://github.com/${ZI_REPO}.git" "${zi_home}/bin"
+          zi_bin="${zi_home}/bin"
+          mkdir -p "${zi_home}"
+          git init "${zi_bin}"
+          git -C "${zi_bin}" remote add origin "https://github.com/${ZI_REPO}.git"
+          git -C "${zi_bin}" fetch --no-tags --depth 1 origin -- "${ZI_REF}"
+          git -C "${zi_bin}" checkout --detach FETCH_HEAD
+          if [[ "${ZI_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            requested_sha="$(printf '%s' "${ZI_REF}" | tr '[:upper:]' '[:lower:]')"
+            [[ "$(git -C "${zi_bin}" rev-parse HEAD)" == "${requested_sha}" ]] || {
+              echo "Resolved Zi commit does not match requested SHA: ${ZI_REF}"
+              exit 1
+            }
+          fi
           mkdir -p "${zi_home}"/{cache,completions,plugins,snippets}
-          [[ -f "${zi_home}/bin/zi.zsh" ]] || { echo "zi.zsh not found after install"; exit 1; }
+          [[ -f "${zi_bin}/zi.zsh" ]] || { echo "zi.zsh not found after install"; exit 1; }
 
       - name: "ZUnit: ${{ matrix.file }}"
         run: |

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: z-shell/zd
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ job.workflow_sha }}
 
       - name: Install zsh
         run: sudo apt-get update && sudo apt-get install -yq zsh

--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -27,19 +27,23 @@ on:
 jobs:
   zd:
     name: "ZUnit suite"
+    permissions:
+      contents: read
     uses: z-shell/zd/.github/workflows/test-native.yml@main
     with:
       zi_repo: z-shell/zi # the repo being tested
-      zi_ref: ${{ github.sha }} # the exact commit under test
+      # PRs use the head commit, not GitHub's synthetic merge commit.
+      zi_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 ```
 
 **What each field does:**
 
-| Field                                                     | Purpose                                                            |
-| --------------------------------------------------------- | ------------------------------------------------------------------ |
-| `uses: z-shell/zd/.github/workflows/test-native.yml@main` | Calls the reusable workflow at the `main` ref of `zd`              |
-| `zi_repo: z-shell/zi`                                     | Tells `zd` to clone this repo instead of using the default install |
-| `zi_ref: ${{ github.sha }}`                               | Pins to the exact commit that triggered the caller's workflow      |
+| Field                                                                                                      | Purpose                                                                    |
+| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `permissions: contents: read`                                                                              | Grants only the repository access required by the reusable workflow        |
+| `uses: z-shell/zd/.github/workflows/test-native.yml@main`                                                  | Calls the reusable workflow at the `main` ref of `zd`                      |
+| `zi_repo: z-shell/zi`                                                                                      | Tells `zd` to clone this repo instead of using the default install         |
+| `zi_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha \|\| github.sha }}` | Pins PRs to their head commit and pushes to the commit that triggered them |
 
 The caller's `GITHUB_TOKEN` is used automatically — no additional secrets are required. Both repositories must be public.
 
@@ -56,11 +60,13 @@ The caller's `GITHUB_TOKEN` is used automatically — no additional secrets are 
 
 ## Choosing `zi_ref`
 
-**`${{ github.sha }}`** — use this in pull request workflows. Tests the exact commit under review. No ambiguity about what is being tested.
+**Exact commit SHA** — use immutable SHAs for both pull requests and pushes. For a pull request, `github.sha` is a synthetic merge commit, so pass `github.event.pull_request.head.sha`. For a push, pass `github.sha`.
 
 ```yaml
-zi_ref: ${{ github.sha }}
+zi_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 ```
+
+The workflow recognizes a full 40-character hexadecimal value as an immutable commit SHA, fetches that object directly, and verifies that the checked-out commit matches it exactly.
 
 **Branch name** — tracks a branch continuously. Useful for nightly runs against `main` without tying to a specific commit.
 
@@ -87,7 +93,7 @@ zi_ref: v1.2.3
 
 ## Pinning the zd version
 
-The `uses:` line can reference `zd` by branch or by tag:
+The `uses:` line can reference `zd` by branch, tag, or commit SHA:
 
 ```yaml
 # Always use the latest zd (may include breaking changes)
@@ -96,8 +102,8 @@ uses: z-shell/zd/.github/workflows/test-native.yml@main
 # Pin to a specific zd release (stable, auditable)
 uses: z-shell/zd/.github/workflows/test-native.yml@v1.0.0
 
-# Pin to a specific commit SHA (most stable)
-uses: z-shell/zd/.github/workflows/test-native.yml@a1b2c3d
+# Pin to a full commit SHA (most stable)
+uses: z-shell/zd/.github/workflows/test-native.yml@a1b2c3d4e5f678901234567890abcdef12345678
 ```
 
-For production CI in a release-tracked repo, pinning to a tag or SHA is recommended. For development repos following Zi's `main` branch, `@main` is sufficient.
+For production CI, pin the reusable workflow itself to a full commit SHA. Branches and tags remain useful for development or release tracking but are mutable references.


### PR DESCRIPTION
# Pull Request type

Type of change that PR introduces:

- [x] CI
- [x] Bugfix
- [ ] Feature
- [ ] Generic maintenance tasks
- [x] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [ ] Improving performance of the project (not introducing new features)
- [ ] Other (please describe):

## What is the current behavior?

The reusable native test workflow passes `zi_ref` to `git clone --branch`, which cannot resolve arbitrary commit SHAs. Callers therefore cannot reliably test the immutable commit receiving a check result.

Closes #93

## What is the new behavior?

The workflow fetches the requested branch, tag, or full commit SHA and checks out `FETCH_HEAD` in detached mode. Full 40-character SHAs are verified against the resolved commit. The cross-repository contract now uses the pull request head SHA for PRs and `github.sha` for pushes, with read-only contents permission.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation:

- `trunk check --no-fix --filter=actionlint,prettier .github/workflows/test-native.yml`
- `trunk check --no-fix --filter=markdownlint,prettier docs/cross-repo.md`
- Live fetch checks against `z-shell/zi` using a branch, tag, lowercase full SHA, and uppercase full SHA
