### PR TITLE
test: cover Zi compatibility contracts

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        file: [annexes, ice, packages, plugins, snippets]
+        file: [annexes, compat, ice, packages, plugins, snippets]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        file: [annexes, compat, ice, packages, plugins, snippets]
+        file: ${{ fromJSON(inputs.zi_repo != '' && '["annexes","compat","ice","packages","plugins","snippets"]' || '["annexes","ice","packages","plugins","snippets"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ZI_DATA    ?= /tmp/zunit-local
 IMAGE      ?= ghcr.io/z-shell/zd
 TAG        ?= latest
 TERM       ?= xterm-256color
-TEST_FILES  = annexes ice packages plugins snippets utils
+TEST_FILES  = annexes compat ice packages plugins snippets utils
 
 ifdef FILE
 _SUITES := tests/$(FILE).zunit

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -18,7 +18,7 @@
 
 The primary CI workflow. Runs on every push to `main` (when `tests/**` or `utils.zsh` change), on all pull requests, on a weekly Monday schedule, and on manual or `workflow_call` dispatch.
 
-**Matrix:** one parallel job per `.zunit` file — `annexes`, `ice`, `packages`, `plugins`, `snippets`. Jobs run with `fail-fast: false` so a failure in one suite does not cancel the others.
+**Matrix:** one parallel job per `.zunit` file — `annexes`, `compat`, `ice`, `packages`, `plugins`, `snippets`. Jobs run with `fail-fast: false` so a failure in one suite does not cancel the others.
 
 **Steps per job:**
 

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -18,7 +18,10 @@
 
 The primary CI workflow. Runs on every push to `main` (when `tests/**` or `utils.zsh` change), on all pull requests, on a weekly Monday schedule, and on manual or `workflow_call` dispatch.
 
-**Matrix:** one parallel job per `.zunit` file — `annexes`, `compat`, `ice`, `packages`, `plugins`, `snippets`. Jobs run with `fail-fast: false` so a failure in one suite does not cancel the others.
+**Matrix:** ordinary ZD runs execute `annexes`, `ice`, `packages`, `plugins`,
+and `snippets`. Reusable calls that provide `zi_repo` also execute `compat`
+against the caller's explicit Zi ref. Jobs run with `fail-fast: false` so a
+failure in one suite does not cancel the others.
 
 **Steps per job:**
 

--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -4,7 +4,12 @@
 
 ## How it works
 
-When called with `zi_repo` and `zi_ref` inputs, `test-native.yml` clones that exact revision of Zi directly instead of using the default install script. The rest of the workflow is identical: the full test matrix runs (`annexes`, `compat`, `ice`, `packages`, `plugins`, `snippets`), and results appear in the caller's GitHub Actions UI.
+When called with `zi_repo` and `zi_ref` inputs, `test-native.yml` clones that
+exact revision of Zi directly instead of using the default install script. The
+full cross-repository matrix then runs (`annexes`, `compat`, `ice`, `packages`,
+`plugins`, `snippets`), and results appear in the caller's GitHub Actions UI.
+The promotion-specific `compat` suite is omitted from ordinary ZD runs that use
+Zi's stable `main` branch.
 
 This means a Zi pull request can trigger `zd` tests as part of its own CI pipeline, catching regressions in the test suite before the PR is merged.
 

--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -4,7 +4,7 @@
 
 ## How it works
 
-When called with `zi_repo` and `zi_ref` inputs, `test-native.yml` clones that exact revision of Zi directly instead of using the default install script. The rest of the workflow is identical: the full test matrix runs (`annexes`, `ice`, `packages`, `plugins`, `snippets`), and results appear in the caller's GitHub Actions UI.
+When called with `zi_repo` and `zi_ref` inputs, `test-native.yml` clones that exact revision of Zi directly instead of using the default install script. The rest of the workflow is identical: the full test matrix runs (`annexes`, `compat`, `ice`, `packages`, `plugins`, `snippets`), and results appear in the caller's GitHub Actions UI.
 
 This means a Zi pull request can trigger `zd` tests as part of its own CI pipeline, catching regressions in the test suite before the PR is merged.
 

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -38,7 +38,14 @@ Every `.zunit` file follows this structure:
 **Signature:**
 
 ```zsh
-zi_test '<zi commands>'
+zi_test '<zi commands>' ['<pre-source configuration>']
+```
+
+Use the optional second argument only when a contract depends on configuration
+that Zi reads while being sourced:
+
+```zsh
+zi_test 'alias zini 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
 ```
 
 **Minimal example:**
@@ -148,6 +155,20 @@ This means tests can be run in any order and do not depend on each other.
 
 ---
 
+## When regression coverage is required
+
+User-visible Zi behavioral changes require focused regression coverage when they
+alter a documented command, option, alias, compatibility helper, or other stable
+interface. Add an assertion that would fail if the reported behavior returned,
+and prefer deterministic parse, help, or isolated-function seams over live
+updates and other user-state mutation. Avoid asserting incidental formatting
+when a stable semantic marker is available.
+
+Internal refactors that preserve observable behavior do not require a new test
+unless they fix a demonstrated regression or change an existing contract.
+
+---
+
 ## Adding a new suite
 
 1. Create `tests/<name>.zunit` following the anatomy above.
@@ -155,7 +176,7 @@ This means tests can be run in any order and do not depend on each other.
 
    ```yaml
    matrix:
-     file: [annexes, ice, packages, plugins, snippets, <name>]
+     file: [annexes, compat, ice, packages, plugins, snippets, <name>]
    ```
 
 3. Verify locally before pushing:

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -174,10 +174,9 @@ unless they fix a demonstrated regression or change an existing contract.
 1. Create `tests/<name>.zunit` following the anatomy above.
 2. Add `<name>` to the matrix in `.github/workflows/test-native.yml`:
 
-   ```yaml
-   matrix:
-     file: [annexes, compat, ice, packages, plugins, snippets, <name>]
-   ```
+   Add it to the appropriate matrix expression in
+   `.github/workflows/test-native.yml`. Keep suites that require an explicit Zi
+   candidate, such as `compat`, in the `zi_repo` branch of that expression.
 
 3. Verify locally before pushing:
 

--- a/tests/compat.zunit
+++ b/tests/compat.zunit
@@ -56,20 +56,23 @@
 }
 
 @test 'internal aliases can be explicitly disabled' {
-  zi_test 'alias zini 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
-  assert $state not_equal_to 0
-
-  zi_test 'alias zinit 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
-  assert $state not_equal_to 0
-
-  zi_test 'alias zplugin 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
-  assert $state not_equal_to 0
+  zi_test '
+    (( ! ${+aliases[zini]} && ! ${+aliases[zinit]} && ! ${+aliases[zplugin]} )) ||
+      exit 1
+    print aliases-disabled
+  ' 'ZI[INTERNAL_ALIASES]=0'
+  assert $state equals 0
+  assert "$output" contains "aliases-disabled"
 }
 
 @test 'version command forms report the checkout version consistently' {
   local expected
-  expected=$(git -C "$ZI_BIN" describe --tags --exact-match 2>/dev/null) ||
-    expected=$(git -C "$ZI_BIN" rev-parse --short HEAD)
+  local zi_bin=${ZI_BIN:-${XDG_DATA_HOME:-${HOME}/.local/share}/zi/bin}
+  expected=$(git -C "$zi_bin" describe --tags --exact-match 2>/dev/null) ||
+    expected=$(git -C "$zi_bin" rev-parse --short=7 HEAD)
+  assert $? equals 0
+  [[ -n $expected ]]
+  assert $? equals 0
 
   zi_test 'zi -V'
   assert $state equals 0

--- a/tests/compat.zunit
+++ b/tests/compat.zunit
@@ -42,12 +42,17 @@
 }
 
 @test 'deprecated command aliases are enabled by default' {
-  zi_test 'alias zini zinit zplugin'
-
+  zi_test 'alias zini'
   assert $state equals 0
-  assert "$output" contains "zini=zi"
-  assert "$output" contains "zinit=zi"
-  assert "$output" contains "zplugin=zi"
+  assert "$output" equals "zini=zi"
+
+  zi_test 'alias zinit'
+  assert $state equals 0
+  assert "$output" equals "zinit=zi"
+
+  zi_test 'alias zplugin'
+  assert $state equals 0
+  assert "$output" equals "zplugin=zi"
 }
 
 @test 'internal aliases can be explicitly disabled' {

--- a/tests/compat.zunit
+++ b/tests/compat.zunit
@@ -1,0 +1,120 @@
+#!/usr/bin/env zunit
+#
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+
+@setup {
+  load setup
+  load helpers
+  setup
+}
+
+@teardown {
+  load teardown
+  teardown
+}
+
+@test 'compatibility helpers delegate to current implementations' {
+  zi_test '
+    zicdreplay() { (( argv[1] == 11 && argv[2] == 12 )) && print cdreplay; }
+    zicdclear() { (( argv[1] == 21 )) && print cdclear; }
+    zicompinit() { (( argv[1] == 31 )) && print compinit; }
+    zicompdef() { (( argv[1] == 41 && argv[2] == 42 )) && print compdef; }
+    ziextract() { (( argv[1] == 51 )) && print extract; }
+    zi() { (( argv[1] == 61 )) && print triangle; }
+
+    zpcdreplay 11 12
+    zpcdclear 21
+    zpcompinit 31
+    zpcompdef 41 42
+    zpextract 51
+    ❮▼❯ 61
+  '
+
+  assert $state equals 0
+  assert "$output" contains "cdreplay"
+  assert "$output" contains "cdclear"
+  assert "$output" contains "compinit"
+  assert "$output" contains "compdef"
+  assert "$output" contains "extract"
+  assert "$output" contains "triangle"
+}
+
+@test 'deprecated command aliases are enabled by default' {
+  zi_test 'alias zini zinit zplugin'
+
+  assert $state equals 0
+  assert "$output" contains "zini=zi"
+  assert "$output" contains "zinit=zi"
+  assert "$output" contains "zplugin=zi"
+}
+
+@test 'internal aliases can be explicitly disabled' {
+  zi_test 'alias zini zinit zplugin 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
+
+  assert $state not_equal_to 0
+}
+
+@test 'version command forms report the checkout version consistently' {
+  local expected
+  expected=$(git -C "$ZI_BIN" describe --tags --exact-match 2>/dev/null) ||
+    expected=$(git -C "$ZI_BIN" rev-parse --short HEAD)
+
+  zi_test 'zi -V'
+  assert $state equals 0
+  assert "$output" contains "$expected"
+
+  zi_test 'zi --version'
+  assert $state equals 0
+  assert "$output" contains "$expected"
+
+  zi_test 'zi version'
+  assert $state equals 0
+  assert "$output" contains "$expected"
+}
+
+@test 'update keeps legacy plugins and snippets option meanings' {
+  zi_test '
+    .zi-update-or-status-all() {
+      (( OPTS[opt_-l,--plugins] && !OPTS[opt_-s,--snippets] )) &&
+        print plugins-only
+    }
+    zi update -L
+  '
+  assert $state equals 0
+  assert "$output" contains "plugins-only"
+
+  zi_test 'zi update -s -h'
+  assert $state equals 1
+  assert "$output" contains "Update only snippets"
+}
+
+@test 'times seconds flags use seconds without changing update short option' {
+  zi_test '
+    ZI[TIME_1_z-shell---contract]=0.125
+    ZI[AT_TIME_1_z-shell---contract]=1.125
+    ZI[START_TIME]=1.000
+    zi times -s
+  '
+  assert $state equals 0
+  assert "$output" contains "0.125 s"
+
+  zi_test '
+    ZI[TIME_1_z-shell---contract]=0.125
+    ZI[AT_TIME_1_z-shell---contract]=1.125
+    ZI[START_TIME]=1.000
+    zi times -S
+  '
+  assert $state equals 0
+  assert "$output" contains "0.125 s"
+
+  zi_test '
+    ZI[TIME_1_z-shell---contract]=0.125
+    ZI[AT_TIME_1_z-shell---contract]=1.125
+    ZI[START_TIME]=1.000
+    zi times --seconds
+  '
+  assert $state equals 0
+  assert "$output" contains "0.125 s"
+}

--- a/tests/compat.zunit
+++ b/tests/compat.zunit
@@ -51,8 +51,13 @@
 }
 
 @test 'internal aliases can be explicitly disabled' {
-  zi_test 'alias zini zinit zplugin 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
+  zi_test 'alias zini 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
+  assert $state not_equal_to 0
 
+  zi_test 'alias zinit 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
+  assert $state not_equal_to 0
+
+  zi_test 'alias zplugin 2>/dev/null' 'ZI[INTERNAL_ALIASES]=0'
   assert $state not_equal_to 0
 }
 
@@ -74,7 +79,7 @@
   assert "$output" contains "$expected"
 }
 
-@test 'update keeps legacy plugins and snippets option meanings' {
+@test 'update keeps legacy plugins-only option meaning' {
   zi_test '
     .zi-update-or-status-all() {
       (( OPTS[opt_-l,--plugins] && !OPTS[opt_-s,--snippets] )) &&
@@ -84,10 +89,19 @@
   '
   assert $state equals 0
   assert "$output" contains "plugins-only"
+}
 
-  zi_test 'zi update -s -h'
-  assert $state equals 1
-  assert "$output" contains "Update only snippets"
+@test 'update keeps snippets-only option meaning' {
+  zi_test '
+    .zi-update-or-status-all() {
+      typeset -p OPTS | grep -Fq "[opt_-s,--snippets]=1" || return 1
+      typeset -p OPTS | grep -Fq "[opt_-l,--plugins]=1" && return 1
+      print snippets-only
+    }
+    zi update -s
+  '
+  assert $state equals 0
+  assert "$output" contains "snippets-only"
 }
 
 @test 'times seconds flags use seconds without changing update short option' {

--- a/tests/helpers.zsh
+++ b/tests/helpers.zsh
@@ -4,6 +4,7 @@
 # Run a zi snippet in a fresh isolated zsh subprocess.
 # $1 — zsh code to execute (unescaped; single-quote at call site to prevent
 #       expansion before the function receives it).
+# $2 — optional zsh code to execute after initializing ZI and before sourcing Zi.
 #
 # Variable interpolation note: ${_zi_bin} and ${_zi_data} are expanded by the
 # outer shell when the inner command string is assembled. References to $VAR
@@ -12,6 +13,7 @@
 # caller: zi_test "zi light ${my_plugin}"
 zi_test() {
   local script=$1
+  local pre_source=${2:-}
   local _zi_bin="${ZI_BIN:-${XDG_DATA_HOME:-${HOME}/.local/share}/zi/bin}"
   local _zi_data="${ZI_DATA:-${TMPDIR:-/tmp}/zunit}"
   run env NO_COLOR=1 TERM=dumb zsh -c "
@@ -19,6 +21,7 @@ zi_test() {
     path=( \${HOME}/go/bin \$path )
     typeset -gA ZI
     ZI[HOME_DIR]='${_zi_data}'
+    ${pre_source}
     source '${_zi_bin}/zi.zsh'
     autoload -Uz _zi
     ${script}


### PR DESCRIPTION
# Pull Request type

Type of change that PR introduces:

- [x] CI
- [ ] Bugfix
- [ ] Feature
- [ ] Generic maintenance tasks
- [x] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [ ] Improving performance of the project (not introducing new features)
- [ ] Other (please describe):

## What is the current behavior?

Promotion-critical compatibility behavior restored by z-shell/zi#368, z-shell/zi#370, and z-shell/zi#372 has no focused regression coverage in the reusable ZUnit suite.

Issue Number: Closes #94

## What is the new behavior?

Adds a deterministic `compat.zunit` suite covering compatibility helper delegation, default aliases and explicit opt-out, all version command forms, legacy `update -L` parsing, and seconds handling for `times -s`, `-S`, and `--seconds` without changing `update -s`. The suite is included in native CI and local test discovery; the Docker matrix already discovers every `.zunit` file.

Test-authoring documentation now requires focused regression coverage for user-visible behavioral changes and documents pre-source configuration through `zi_test`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation:

- `make test FILE=compat ZI_BIN=<Zi next checkout at f3e68af>` — 6/6 tests passed
- Negative control at Zi `624c8c3` (before the compatibility fixes) failed the helper, alias, version, update, and times regression categories as expected
- `git diff --check`
- `zsh -n tests/helpers.zsh`

All requested contracts are covered. The triangle wrapper is tested through deterministic delegate substitution rather than invoking mutable Zi behavior.

Depends on #95 and intentionally targets `ss-o-support-immutable-zi-refs`.
