### PR TITLE
fix: avoid shadowing ZSH_VERSION in pack-zsh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ZI_DATA    ?= /tmp/zunit-local
 IMAGE      ?= ghcr.io/z-shell/zd
 TAG        ?= latest
 TERM       ?= xterm-256color
-TEST_FILES  = annexes ice packages plugins snippets
+TEST_FILES  = annexes ice packages plugins snippets utils
 
 ifdef FILE
 _SUITES := tests/$(FILE).zunit

--- a/docker/utils.zsh
+++ b/docker/utils.zsh
@@ -75,7 +75,7 @@ zi::setup-minimal() {
 }
 
 zi::pack-zsh() {
-  local ZSH_VERSION="$1"
-  zi pack"$ZSH_VERSION" for zsh
+  local target_zsh_version="$1"
+  zi pack"$target_zsh_version" for zsh
   zi pack atload=+"zicompinit; zicdreplay" for system-completions
 }

--- a/tests/fixtures/pack-zsh.zsh
+++ b/tests/fixtures/pack-zsh.zsh
@@ -1,0 +1,13 @@
+#!/usr/bin/env zsh
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+expected_zsh_version=$ZSH_VERSION
+
+zi() {
+  [[ $ZSH_VERSION == $expected_zsh_version ]] || return 91
+  print -r -- "$*"
+}
+
+source "$1"
+zi::pack-zsh 5.9

--- a/tests/utils.zunit
+++ b/tests/utils.zunit
@@ -1,0 +1,10 @@
+#!/usr/bin/env zunit
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+@test 'pack-zsh preserves the shell ZSH_VERSION parameter' {
+  run zsh -f ./tests/fixtures/pack-zsh.zsh ./docker/utils.zsh
+
+  assert $state equals 0
+  assert "$output" contains 'pack5.9 for zsh'
+}


### PR DESCRIPTION
Closes #97.

## Summary
- use a local target version variable instead of special parameter shadowing
- cover the pack-zsh path with a focused ZUnit regression

## Verification
- `make test FILE=utils`
- full `make test`
- included in the strict 19-file corpus with zero errors and zero warnings