### PR TITLE
ci(docker): build arm64 natively instead of under QEMU

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,65 +24,111 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Builds one single-arch image per (Zsh version, architecture) pair on a
+  # native runner for that architecture. No QEMU: linux/arm64 legs run on
+  # GitHub-hosted ubuntu-24.04-arm runners instead of emulating arm64 on an
+  # amd64 runner, which removes the emulation tax and the setup-qemu-action
+  # binfmt-cache contention entirely. On pull_request the arm64 leg stops
+  # after checkout (see the per-step `if:` below); PRs never publish, so
+  # there is nothing for it to validate that the amd64 leg does not already
+  # cover.
   build-versioned:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
+        zsh_version: ["5.5.1", "5.6.2", "5.7.1", "5.8", "5.8.1", "5.9"]
+        arch: [amd64, arm64]
         include:
-          - { zsh_version: "5.5.1" }
-          - { zsh_version: "5.6.2" }
-          - { zsh_version: "5.7.1" }
-          - { zsh_version: "5.8" }
-          - { zsh_version: "5.8.1" }
-          - { zsh_version: "5.9" }
+          - { arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      # `matrix` is not available in a job-level `if:`, only in step-level
+      # `if:`, so each of the remaining steps is individually gated here
+      # rather than the whole job. On pull_request, only amd64 continues
+      # past checkout; PRs never publish, so an arm64 leg would validate
+      # nothing the amd64 leg does not already cover.
       - name: Set up Docker Buildx
         id: buildx
+        if: github.event_name != 'pull_request' || matrix.arch == 'amd64'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
           use: true
       - uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
+        if: github.event_name != 'pull_request' || matrix.arch == 'amd64'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build_zsh_versions
+        if: github.event_name != 'pull_request' || matrix.arch == 'amd64'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         timeout-minutes: 60
         with:
-          push: ${{ github.event.number == 0 }}
+          push: ${{ github.event_name != 'pull_request' }}
           file: ./docker/Dockerfile
           context: .
           build-args: ZSH_VERSION=${{ matrix.zsh_version }}
-          tags: ghcr.io/${{ github.repository }}:zsh-${{ matrix.zsh_version }}
-          # PRs never push or load a multi-platform result, so building
-          # arm64 under QEMU on every PR only costs time. Full multi-arch
-          # builds run on push/schedule/dispatch, where the image ships.
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-          # Scoped per Zsh version: an unscoped `type=gha` cache is shared
-          # across the whole matrix, so concurrent legs overwrite each
-          # other's cache and only one version ever gets a real hit.
-          cache-from: type=gha,scope=docker-${{ matrix.zsh_version }}
+          tags: ghcr.io/${{ github.repository }}:zsh-${{ matrix.zsh_version }}-${{ matrix.arch }}
+          platforms: ${{ matrix.platform }}
+          # Scoped per Zsh version and arch: an unscoped `type=gha` cache is
+          # shared across the whole matrix, so concurrent legs overwrite
+          # each other's cache and only one leg ever gets a real hit.
+          cache-from: type=gha,scope=docker-${{ matrix.zsh_version }}-${{ matrix.arch }}
           # PR-run cache writes are scoped to the PR ref and can never be
           # read by main or any other PR (GitHub Actions cache is
           # branch-isolated), so skip the mode=max export cost on PRs.
-          cache-to: ${{ github.event_name == 'pull_request' && format('type=gha,scope=docker-{0}', matrix.zsh_version) || format('type=gha,scope=docker-{0},mode=max', matrix.zsh_version) }}
+          cache-to: ${{ github.event_name == 'pull_request' && format('type=gha,scope=docker-{0}-{1}', matrix.zsh_version, matrix.arch) || format('type=gha,scope=docker-{0}-{1},mode=max', matrix.zsh_version, matrix.arch) }}
 
-  build-latest:
+  # Joins each Zsh version's per-arch images (built above) into the
+  # published multi-arch manifest list, matching the pre-split `zsh-<version>`
+  # tag. imagetools operates on images already in the registry, so this only
+  # runs where build-versioned actually pushed, never on pull_request.
+  publish-versioned:
+    needs: build-versioned
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        zsh_version: ["5.5.1", "5.6.2", "5.7.1", "5.8", "5.8.1", "5.9"]
+    steps:
+      - uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag "ghcr.io/${{ github.repository }}:zsh-${{ matrix.zsh_version }}" \
+            "ghcr.io/${{ github.repository }}:zsh-${{ matrix.zsh_version }}-amd64" \
+            "ghcr.io/${{ github.repository }}:zsh-${{ matrix.zsh_version }}-arm64"
+
+  # Same per-arch-then-join split as build-versioned/publish-versioned,
+  # for the `latest` tag. Job-level `if` (rather than the previous
+  # step-level `if`) skips checkout/buildx/login entirely off `main`.
+  build-latest:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - { arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
@@ -96,13 +142,30 @@ jobs:
       - name: Build and push
         id: docker_build_latest
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        if: github.ref == 'refs/heads/main'
         timeout-minutes: 30
         with:
           push: true
           file: ./docker/Dockerfile
           context: .
-          tags: ghcr.io/${{ github.repository }}:latest
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=docker-latest
-          cache-to: type=gha,scope=docker-latest,mode=max
+          tags: ghcr.io/${{ github.repository }}:latest-${{ matrix.arch }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=docker-latest-${{ matrix.arch }}
+          cache-to: type=gha,scope=docker-latest-${{ matrix.arch }},mode=max
+
+  publish-latest:
+    needs: build-latest
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag "ghcr.io/${{ github.repository }}:latest" \
+            "ghcr.io/${{ github.repository }}:latest-amd64" \
+            "ghcr.io/${{ github.repository }}:latest-arm64"

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -93,27 +93,52 @@ Builds and publishes multi-architecture images (`linux/amd64`, `linux/arm64`) to
 
 **Jobs:**
 
-`build-versioned` — builds one image per Zsh version (5.5.1–5.9) with tag `zsh-<version>`. Images are pushed only when the trigger is not a pull request (`github.event.number == 0`).
+Each architecture builds natively rather than through QEMU emulation:
+`linux/amd64` legs run on `ubuntu-latest`, `linux/arm64` legs run on the
+GitHub-hosted `ubuntu-24.04-arm` runner. There is no `docker/setup-qemu-action`
+step anywhere in this workflow.
 
-`build-latest` — builds the `latest` tag. Pushed only on `main` branch pushes.
+`build-versioned`: matrix of Zsh version (5.5.1–5.9) times architecture
+(`amd64`, `arm64`), 12 legs on `push`/`schedule`/`workflow_dispatch`. Each
+leg builds and pushes a single-arch, arch-suffixed tag
+(`zsh-<version>-amd64`, `zsh-<version>-arm64`). On `pull_request`, only the
+`amd64` leg runs (skipped via a job-level `if`) and nothing is pushed: PRs
+never publish, so an arm64 leg would validate nothing the amd64 leg does not
+already cover.
 
-Layer caching uses `type=gha` for both jobs, scoped per Zsh version
-(`scope=docker-<version>`, `scope=docker-latest`) for the same reason as
-`test-matrix.yml` above.
+`publish-versioned`: depends on `build-versioned`, one job per Zsh version.
+Runs `docker buildx imagetools create` to join that version's `-amd64` and
+`-arm64` tags into the published multi-arch `zsh-<version>` tag. `imagetools`
+operates on images already in the registry, so this job (like
+`build-latest`'s arm64 leg pushing) only runs off `pull_request`.
 
-On `pull_request` runs, `build-versioned` builds `linux/amd64` only and skips
-the `mode=max` cache export. Pull requests never push or load a
-multi-platform result (`push` evaluates to `false`, and there is no `load:`),
-so building `linux/arm64` under QEMU emulation on every PR only costs time.
-GitHub Actions cache is also branch-isolated: a cache a PR run writes is
-scoped to that PR and can never be restored by `main` or another PR, so
+`build-latest`/`publish-latest`: the same per-arch-build-then-join split,
+for the `latest` tag. Gated at the job level on `github.ref ==
+'refs/heads/main'`, so pull requests and non-`main` triggers skip checkout,
+Buildx setup, and login entirely rather than running them only to skip the
+build step.
+
+The per-arch `-amd64`/`-arm64` tags remain in the registry alongside the
+joined manifest tags; they are not deleted after `imagetools create` runs.
+This is a deliberate simplicity tradeoff, not an oversight; cleaning them up
+would need a further step calling the GitHub Packages API.
+
+Layer caching uses `type=gha` for every build job, scoped per Zsh version
+**and architecture** (`scope=docker-<version>-<arch>`, `scope=docker-latest-<arch>`)
+for the same reason as `test-matrix.yml` above: an unscoped or
+under-scoped cache lets concurrent legs overwrite each other's cache, so
+only one leg would ever get a real hit.
+
+On `pull_request` runs, `build-versioned`'s single `amd64` leg also skips
+the `mode=max` cache export, since GitHub Actions cache is branch-isolated:
+a cache a PR run writes can never be restored by `main` or another PR, so
 exporting it there is pure cost. `push`/`schedule`/`workflow_dispatch` runs
-still build and cache both platforms, since those are the runs that publish.
+still cache normally, since those are the runs that publish.
 
-Both jobs set an explicit `timeout-minutes` (job-level, in addition to the
-existing 60-minute step-level timeout on the build step) so a stuck build
-fails within a bounded window instead of falling back to GitHub's 360-minute
-default.
+All four jobs set an explicit `timeout-minutes` (job-level, in addition to
+the existing 60-minute step-level timeout on the build step in
+`build-versioned`/`build-latest`) so a stuck build fails within a bounded
+window instead of falling back to GitHub's 360-minute default.
 
 ---
 


### PR DESCRIPTION
Addresses #101.

## Problem

`docker.yml` built `linux/amd64,linux/arm64` as a single multi-platform `docker/build-push-action` invocation per Zsh version, emulating `arm64` on an `amd64` runner via `docker/setup-qemu-action`. Compiling Zsh from source under QEMU emulation is markedly slower than native, and was a likely contributor to the `5.5.1` build stall investigated in #99 (that stall itself turned out to be an unrelated zunit build-script hang, but the emulation cost is real and independent of that finding).

Researched on #101: GitHub-hosted Linux ARM64 runners (`ubuntu-24.04-arm`) are now generally available in the standard runner tier, not the paid "larger runners" tier, priced at roughly 0.83x the Linux x64 rate where billing applies at all, and free for this public repository the same as `ubuntu-latest` today. That makes native arm64 runners a straightforward improvement over QEMU with no cost or infrastructure tradeoff.

## Changes

- Split `build-versioned` and `build-latest` into a per-architecture matrix: `amd64` legs run on `ubuntu-latest`, `arm64` legs run on `ubuntu-24.04-arm`. Each leg builds and pushes a single-arch, arch-suffixed tag (`zsh-<version>-amd64`/`-arm64`, `latest-amd64`/`-arm64`).
- Added `publish-versioned` and `publish-latest` join jobs that run `docker buildx imagetools create` to combine each version's per-arch tags into the existing published `zsh-<version>`/`latest` tags. These only run where the build jobs actually pushed (never on `pull_request`), since `imagetools` operates on images already in the registry.
- Dropped `docker/setup-qemu-action` entirely; no longer needed.
- Cache scope now includes architecture (`docker-<version>-<arch>`, `docker-latest-<arch>`), narrowing the #100 fix further now that each version has two independent native builds instead of one emulated multi-platform build.
- Gated `build-latest` at the job level on `github.ref == 'refs/heads/main'` instead of only the build step, so non-`main` triggers skip checkout/Buildx/login entirely rather than running them only to skip the build.
- Simplified `build-versioned`'s push condition from the `github.event.number == 0` idiom to `github.event_name != 'pull_request'` while restructuring this job anyway.
- Updated `docs/ci-workflows.md` for the new per-arch-then-join shape.

## Known tradeoffs

- The interim `-amd64`/`-arm64` tags are left in the registry alongside the joined manifest tags; they are not deleted after `imagetools create` runs. Cleaning them up would need a further step calling the GitHub Packages API, out of scope here.
- GitHub Actions has no per-matrix-entry job dependency, so `publish-versioned` (`needs: build-versioned`) waits for every leg of `build-versioned` (all 12) before any version's join runs, not just that version's own amd64/arm64 pair. The join step itself is fast, so this is a minor serialization, not a correctness issue.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(...))'` on the changed workflow file: valid YAML.
- No `actionlint` available locally in this environment; relying on this PR's own `docker.yml` run plus reviewer check, including confirming `ubuntu-24.04-arm` is usable for this org/repo without further enablement.
