### PR TITLE
ci: enforce zsh-lint reference corpus

### DIFF
--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   zsh-lint:
     name: Zsh Lint
-    uses: z-shell/.github/.github/workflows/zsh-lint.yml@3bb97532c6ae5db09a38bdffe9a85cb2b0a97bba
+    uses: z-shell/.github/.github/workflows/zsh-lint.yml@2d4a2119da7de4226a3f5c8da749138f3b853413
     with:
       zsh-lint-ref: 3c4966b454fc07a346772a24d8311adab91414ed
       paths: |

--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   zsh-lint:
     name: Zsh Lint
-    uses: z-shell/.github/.github/workflows/zsh-lint.yml@2d4a2119da7de4226a3f5c8da749138f3b853413
+    uses: z-shell/.github/.github/workflows/zsh-lint.yml@6dca2bef75c60106cde7237db5dea2c2eeed243b
     with:
       zsh-lint-ref: 3c4966b454fc07a346772a24d8311adab91414ed
       paths: |

--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -1,0 +1,37 @@
+---
+name: Zsh Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/utils.zsh"
+      - "docker/zshrc"
+      - "docker/zshenv"
+      - ".github/workflows/zsh-lint.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docker/utils.zsh"
+      - "docker/zshrc"
+      - "docker/zshenv"
+      - ".github/workflows/zsh-lint.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zsh-lint:
+    name: Zsh Lint
+    uses: z-shell/.github/.github/workflows/zsh-lint.yml@3bb97532c6ae5db09a38bdffe9a85cb2b0a97bba
+    with:
+      zsh-lint-ref: 3c4966b454fc07a346772a24d8311adab91414ed
+      paths: |
+        docker/utils.zsh
+        docker/zshrc
+        docker/zshenv


### PR DESCRIPTION
Part of z-shell/.github#505.

Adds the approved strict reference-corpus caller. It pins both the shared workflow and analyzer commits, has no suppression or waiver mechanism, and does not change required checks or rulesets.