### PR TITLE
fix(ci): scope compatibility suite to promotions

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -27,6 +27,11 @@ on:
         description: "Branch, tag, or full commit SHA of zi to test."
         required: false
         default: "main"
+      include_compat:
+        description: "Run the promotion-specific Zi compatibility suite."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       zi_repo:
@@ -39,6 +44,11 @@ on:
         type: string
         required: false
         default: "main"
+      include_compat:
+        description: "Run the promotion-specific Zi compatibility suite."
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   zunit:
@@ -46,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        file: ${{ fromJSON(inputs.zi_repo != '' && '["annexes","compat","ice","packages","plugins","snippets"]' || '["annexes","ice","packages","plugins","snippets"]') }}
+        file: ${{ fromJSON(inputs.include_compat && '["annexes","compat","ice","packages","plugins","snippets"]' || '["annexes","ice","packages","plugins","snippets"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -19,9 +19,9 @@
 The primary CI workflow. Runs on every push to `main` (when `tests/**` or `utils.zsh` change), on all pull requests, on a weekly Monday schedule, and on manual or `workflow_call` dispatch.
 
 **Matrix:** ordinary ZD runs execute `annexes`, `ice`, `packages`, `plugins`,
-and `snippets`. Reusable calls that provide `zi_repo` also execute `compat`
-against the caller's explicit Zi ref. Jobs run with `fail-fast: false` so a
-failure in one suite does not cancel the others.
+and `snippets`. Reusable calls that set `include_compat: true` also execute
+`compat` against the caller's explicit Zi ref. Jobs run with `fail-fast: false`
+so a failure in one suite does not cancel the others.
 
 **Steps per job:**
 

--- a/docs/cross-repo.md
+++ b/docs/cross-repo.md
@@ -5,11 +5,12 @@
 ## How it works
 
 When called with `zi_repo` and `zi_ref` inputs, `test-native.yml` clones that
-exact revision of Zi directly instead of using the default install script. The
-full cross-repository matrix then runs (`annexes`, `compat`, `ice`, `packages`,
-`plugins`, `snippets`), and results appear in the caller's GitHub Actions UI.
-The promotion-specific `compat` suite is omitted from ordinary ZD runs that use
-Zi's stable `main` branch.
+exact revision of Zi directly instead of using the default install script.
+Callers may set `include_compat: true` to add the promotion-specific `compat`
+suite to the standard matrix (`annexes`, `ice`, `packages`, `plugins`,
+`snippets`). Results appear in the caller's GitHub Actions UI. Keep
+`include_compat` false for hotfixes based on Zi's stable `main` branch; enable it
+for a reviewed `next` promotion candidate.
 
 This means a Zi pull request can trigger `zd` tests as part of its own CI pipeline, catching regressions in the test suite before the PR is merged.
 
@@ -39,6 +40,7 @@ jobs:
       zi_repo: z-shell/zi # the repo being tested
       # PRs use the head commit, not GitHub's synthetic merge commit.
       zi_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      include_compat: ${{ github.head_ref == 'next' }}
 ```
 
 **What each field does:**
@@ -49,6 +51,7 @@ jobs:
 | `uses: z-shell/zd/.github/workflows/test-native.yml@main`                                                  | Calls the reusable workflow at the `main` ref of `zd`                      |
 | `zi_repo: z-shell/zi`                                                                                      | Tells `zd` to clone this repo instead of using the default install         |
 | `zi_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha \|\| github.sha }}` | Pins PRs to their head commit and pushes to the commit that triggered them |
+| `include_compat: ${{ github.head_ref == 'next' }}`                                                         | Adds promotion compatibility tests only for a `next` candidate             |
 
 The caller's `GITHUB_TOKEN` is used automatically — no additional secrets are required. Both repositories must be public.
 
@@ -56,10 +59,11 @@ The caller's `GITHUB_TOKEN` is used automatically — no additional secrets are 
 
 ## Input reference
 
-| Input     | Type     | Required | Default | Description                                                                                |
-| --------- | -------- | -------- | ------- | ------------------------------------------------------------------------------------------ |
-| `zi_repo` | `string` | No       | `""`    | GitHub repo for Zi in `owner/name` format. When empty, the default install script is used. |
-| `zi_ref`  | `string` | No       | `main`  | Branch name, tag, or full commit SHA to check out.                                         |
+| Input            | Type      | Required | Default | Description                                                                                |
+| ---------------- | --------- | -------- | ------- | ------------------------------------------------------------------------------------------ |
+| `zi_repo`        | `string`  | No       | `""`    | GitHub repo for Zi in `owner/name` format. When empty, the default install script is used. |
+| `zi_ref`         | `string`  | No       | `main`  | Branch name, tag, or full commit SHA to check out.                                         |
+| `include_compat` | `boolean` | No       | `false` | Add the promotion-specific compatibility suite to the standard matrix.                     |
 
 ---
 

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -176,7 +176,8 @@ unless they fix a demonstrated regression or change an existing contract.
 
    Add it to the appropriate matrix expression in
    `.github/workflows/test-native.yml`. Keep suites that require an explicit Zi
-   candidate, such as `compat`, in the `zi_repo` branch of that expression.
+   candidate, such as `compat`, in the `include_compat` branch of that
+   expression.
 
 3. Verify locally before pushing:
 


### PR DESCRIPTION
## Summary

- add an explicit `include_compat` reusable-workflow input
- keep ordinary and hotfix validation on the stable Zi contract
- enable focused compatibility assertions only for a reviewed `next` promotion candidate

## Validation

- actionlint
- Trunk actionlint, markdownlint, Prettier, and git-diff-check

Follow-up to #96 required by the live Zi bootstrap run.